### PR TITLE
FSA-5294: Cleans up state when claim is being resumed

### DIFF
--- a/projects/fsastorefrontlib/src/core/user-request/store/reducers/index.ts
+++ b/projects/fsastorefrontlib/src/core/user-request/store/reducers/index.ts
@@ -42,7 +42,8 @@ export function clearUserRequestState(
   return function (state, action) {
     if (
       action.type === AuthActions.LOGOUT ||
-      action.type === fromClaimAction.CREATE_CLAIM
+      action.type === fromClaimAction.CREATE_CLAIM ||
+      action.type === fromClaimAction.LOAD_CURRENT_CLAIM
     ) {
       state = undefined;
     }


### PR DESCRIPTION
At SUCCESS Action it will be populated but now with Claim that is being resumed instead of last updated.