### PR TITLE
FSA-5472: Fix for form submit after login

### DIFF
--- a/projects/dynamicforms/src/core/store/effects/form-data.effect.ts
+++ b/projects/dynamicforms/src/core/store/effects/form-data.effect.ts
@@ -47,7 +47,7 @@ export class FormDataEffects {
 
   @Effect({ dispatch: false })
   clearFormData$ = this.actions$.pipe(
-    ofType(AuthActions.LOGOUT),
+    ofType(AuthActions.LOGOUT, AuthActions.LOGIN),
     tap(_ => {
       this.formDataStorageService.clearFormDataLocalStorage();
     })

--- a/projects/dynamicforms/src/occ/adapters/form/occ-form.adapter.ts
+++ b/projects/dynamicforms/src/occ/adapters/form/occ-form.adapter.ts
@@ -1,6 +1,6 @@
 import { HttpClient, HttpParams } from '@angular/common/http';
 import { Injectable } from '@angular/core';
-import { OccEndpointsService, OCC_USER_ID_CURRENT } from '@spartacus/core';
+import { OccEndpointsService } from '@spartacus/core';
 import { Observable, throwError } from 'rxjs';
 import { catchError } from 'rxjs/operators';
 import { FormAdapter } from '../../../core/connectors/form.adapter';

--- a/projects/dynamicforms/src/occ/adapters/form/occ-form.adapter.ts
+++ b/projects/dynamicforms/src/occ/adapters/form/occ-form.adapter.ts
@@ -34,7 +34,7 @@ export class OccFormAdapter implements FormAdapter {
     if (formData.id) {
       const formDataId = formData.id;
       const updateUrl = this.occEndpointService.getUrl('formData', {
-        userId: OCC_USER_ID_CURRENT,
+        userId: userId,
         formDataId,
       });
       return this.http


### PR DESCRIPTION
Old formDataId must be removed from storage since anonymous form data can't be updated with logged in customer.
Reducer function clearFormDefinitionState already removes item DYNAMIC_FORMS_LOCAL_STORAGE_KEY, but variable formLocalStorageData from FormDataStorageService is not updated, old form id is kept until refresh of the page

[banking Loan problem] Changed current user for OCC call because anonymous user can't submit first configure product form at all, "current" parameter for anonymous user can't be authenticated.