### PR TITLE
FSA-5525: Removed deprecated library, import fixed

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "@nguniversal/express-engine": "^10.1.0",
     "@spartacus/assets": "3.0.0",
     "@spartacus/core": "3.0.0",
-    "@spartacus/misc": "^3.0.0-rc.2",
+    "@spartacus/storefinder": "^3.0.0-rc.2",
     "@spartacus/storefront": "3.0.0",
     "@spartacus/styles": "3.0.0",
     "@types/googlemaps": "^3.37.5",

--- a/projects/dynamicforms/src/components/upload/upload.component.ts
+++ b/projects/dynamicforms/src/components/upload/upload.component.ts
@@ -19,7 +19,7 @@ import { DynamicFormsConfig } from '../../core/config/form-config';
 import { FileService } from '../../core/services/file/file.service';
 import { AbstractFormComponent } from '../abstract-form/abstract-form.component';
 import { FormService } from './../../core/services/form/form.service';
-import { FormDataService } from '../../core/services';
+import { FormDataService } from '../../core/services/data/form-data.service';
 import { FieldConfig } from '../../core';
 
 @Component({

--- a/projects/fsastorefrontlib/src/cms-components/agent/agent-search-box/agent-search-box.component.ts
+++ b/projects/fsastorefrontlib/src/cms-components/agent/agent-search-box/agent-search-box.component.ts
@@ -1,6 +1,6 @@
 import { Component, OnInit } from '@angular/core';
 import { RoutingService } from '@spartacus/core';
-import { StoreFinderSearchComponent } from '@spartacus/misc/storefinder/components';
+import { StoreFinderSearchComponent } from '@spartacus/storefinder/components';
 
 @Component({
   selector: 'cx-fs-agent-search-box',

--- a/projects/fsastorefrontlib/src/cms-components/agent/agent.module.ts
+++ b/projects/fsastorefrontlib/src/cms-components/agent/agent.module.ts
@@ -23,8 +23,8 @@ import { AgentSearchListComponent } from './agent-search-list/agent-search-list.
 import { ContactAgentFormComponent } from './contact-agent-form/contact-agent-form.component';
 
 import { AgentConnector } from '../../core/agent/connectors/agent.connector';
-import { StoreFinderComponentsModule } from '@spartacus/misc/storefinder/components';
-import { StoreFinderModule } from '@spartacus/misc';
+import { StoreFinderComponentsModule } from '@spartacus/storefinder/components';
+import { StoreFinderModule } from '@spartacus/storefinder';
 
 @NgModule({
   imports: [

--- a/projects/fsastorefrontstyles/_index.scss
+++ b/projects/fsastorefrontstyles/_index.scss
@@ -1,6 +1,6 @@
 //Spartacus styling
 @import '~@spartacus/styles/index';
-@import '~@spartacus/misc/storefinder/index';
+@import '~@spartacus/storefinder/index';
 //FSA styling
 @import 'scss/root.scss';
 @import 'scss/fs-mixins';


### PR DESCRIPTION
Removed deprecated Spartacus Misc library - Spartacus Storefinder used instead. Fixed import for upload component. Issue found during build of production package.