### PR TITLE
FSA-5517: Scroll position restoration enabled in checkout

### DIFF
--- a/projects/fsastorefrontlib/src/cms-components/checkout/checkout.module.ts
+++ b/projects/fsastorefrontlib/src/cms-components/checkout/checkout.module.ts
@@ -197,7 +197,9 @@ const routes: Routes = [
     UrlModule,
     FSCheckoutProgressModule,
     FSCheckoutStoreModule,
-    RouterModule.forChild(routes),
+    RouterModule.forRoot(routes, {
+      scrollPositionRestoration: 'enabled',
+    }),
     EffectsModule.forFeature(effects),
     ConfigModule.withConfig(<CmsConfig | RoutesConfig | RoutingConfig>{
       cmsComponents: {


### PR DESCRIPTION
This happened because Spartacus dropped the enabled scrollPositionRestoration. It was dropped because of:

- when you use child routes, the scrollPositionRestoration kicks in when you change the child routes
- when you navigate from route to route, the scrollPositionRestoration kicks in even if the new view is already in the viewport

scrollPositionRestoration will be enabled only for checkout pages as it is described in the task.

Btw, spartacus is working on something to make this more configurable :)