### PR TITLE
FSA-5671: Personal details address

### DIFF
--- a/projects/dynamicforms/src/core/config/default-form-config.ts
+++ b/projects/dynamicforms/src/core/config/default-form-config.ts
@@ -14,6 +14,7 @@ import { UserPrefillResolver } from '../resolvers/user-prefill-resolver';
 import { DataHolderComponent } from '../../components/data-holder/data-holder.component';
 import { UploadComponent } from '../../components/upload/upload.component';
 import { CurrentDatePrefillResolver } from '../resolvers/current-date-prefill-resolver';
+import { UserAddressPrefillResolver } from '../resolvers/user-address-prefill-resolver';
 
 export const defaultFormConfig: DynamicFormsConfig = {
   dynamicForms: {
@@ -103,6 +104,9 @@ export const defaultFormConfig: DynamicFormsConfig = {
       },
     },
     prefill: {
+      address: {
+        prefillResolver: UserAddressPrefillResolver,
+      },
       user: {
         prefillResolver: UserPrefillResolver,
       },

--- a/projects/dynamicforms/src/core/resolvers/index.ts
+++ b/projects/dynamicforms/src/core/resolvers/index.ts
@@ -1,2 +1,3 @@
 export * from './prefill-resolver.interface';
 export * from './user-prefill-resolver';
+export * from './user-address-prefill-resolver';

--- a/projects/dynamicforms/src/core/resolvers/user-address-prefill-resolver.spec.ts
+++ b/projects/dynamicforms/src/core/resolvers/user-address-prefill-resolver.spec.ts
@@ -9,12 +9,14 @@ const lastName = 'Moore';
 const street = 'Omladinskih brigada';
 const streetNumber = '2';
 
-const mockAddress = {
-  firstName: firstName,
-  lastName: lastName,
-  line1: street,
-  line2: streetNumber,
-};
+const mockAddress = [
+  {
+    firstName: firstName,
+    lastName: lastName,
+    line1: street,
+    line2: streetNumber,
+  },
+];
 class MockUserAddressService {
   getAddresses() {
     return of(mockAddress);
@@ -52,7 +54,7 @@ describe('UserAddressPrefillResolver', () => {
   });
 
   it('should resolve undefined address line', () => {
-    spyOn(userAddressService, 'getAddresses').and.returnValue(of());
+    spyOn(userAddressService, 'getAddresses').and.returnValue(of([]));
     userAddressesPrefillResolver
       .getPrefillValue(mockFieldPath)
       .subscribe(value => {

--- a/projects/dynamicforms/src/core/resolvers/user-address-prefill-resolver.spec.ts
+++ b/projects/dynamicforms/src/core/resolvers/user-address-prefill-resolver.spec.ts
@@ -1,0 +1,63 @@
+import { TestBed } from '@angular/core/testing';
+import { StoreModule } from '@ngrx/store';
+import { I18nTestingModule, UserAddressService } from '@spartacus/core';
+import { of } from 'rxjs';
+import { UserAddressPrefillResolver } from './user-address-prefill-resolver';
+
+const firstName = 'Donna';
+const lastName = 'Moore';
+const street = 'Omladinskih brigada';
+const streetNumber = '2';
+
+const mockAddress = {
+  firstName: firstName,
+  lastName: lastName,
+  line1: street,
+  line2: streetNumber,
+};
+class MockUserAddressService {
+  getAddresses() {
+    return of(mockAddress);
+  }
+}
+const mockFieldPath = 'line1';
+
+describe('UserAddressPrefillResolver', () => {
+  let userAddressesPrefillResolver: UserAddressPrefillResolver;
+  let userAddressService: UserAddressService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [I18nTestingModule, StoreModule.forRoot({})],
+      providers: [
+        { provide: UserAddressService, useClass: MockUserAddressService },
+      ],
+    });
+
+    userAddressesPrefillResolver = TestBed.inject(UserAddressPrefillResolver);
+    userAddressService = TestBed.inject(UserAddressService);
+  });
+
+  it('should inject user address resolver', () => {
+    expect(userAddressesPrefillResolver).toBeTruthy();
+  });
+
+  it('should resolve address line', () => {
+    userAddressesPrefillResolver
+      .getPrefillValue(mockFieldPath)
+      .subscribe(value => {
+        expect(value).toEqual(street);
+      })
+      .unsubscribe();
+  });
+
+  it('should resolve undefined address line', () => {
+    spyOn(userAddressService, 'getAddresses').and.returnValue(of());
+    userAddressesPrefillResolver
+      .getPrefillValue(mockFieldPath)
+      .subscribe(value => {
+        expect(value).toEqual(' ');
+      })
+      .unsubscribe();
+  });
+});

--- a/projects/dynamicforms/src/core/resolvers/user-address-prefill-resolver.ts
+++ b/projects/dynamicforms/src/core/resolvers/user-address-prefill-resolver.ts
@@ -1,0 +1,28 @@
+import { UserAddressService } from '@spartacus/core';
+import { map } from 'rxjs/operators';
+import { Injectable } from '@angular/core';
+import { PrefillResolver } from './prefill-resolver.interface';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class UserAddressPrefillResolver implements PrefillResolver {
+  constructor(protected userAddressService: UserAddressService) {}
+
+  getPrefillValue(fieldPath: string) {
+    const attributes = fieldPath.split('.');
+    let currentValue;
+    return this.userAddressService.getAddresses().pipe(
+      map(address => {
+        currentValue = address[0];
+        if (!currentValue) {
+          return ' ';
+        }
+        attributes.forEach(attribute => {
+          currentValue = currentValue[attribute];
+        });
+        return currentValue;
+      })
+    );
+  }
+}

--- a/projects/fsastorefrontlib/src/cms-components/form/personal-details/personal-details.component.spec.ts
+++ b/projects/fsastorefrontlib/src/cms-components/form/personal-details/personal-details.component.spec.ts
@@ -11,6 +11,7 @@ import {
   Cart,
   CmsComponent,
   I18nTestingModule,
+  UserAddressService,
 } from '@spartacus/core';
 import { CmsComponentData, SpinnerModule } from '@spartacus/storefront';
 import { Observable, of } from 'rxjs';
@@ -85,6 +86,9 @@ class MockActiveCartService {
     return of();
   }
 }
+class MockUserAddressService {
+  loadAddresses() {}
+}
 const componentData = {
   uid: 'TestPersonalDetailsComponent',
   typeCode: 'PersonalDetailsComponent',
@@ -116,6 +120,10 @@ describe('PersonalDetailsComponent', () => {
           {
             provide: ActiveCartService,
             useClass: MockActiveCartService,
+          },
+          {
+            provide: UserAddressService,
+            useClass: MockUserAddressService,
           },
           {
             provide: CmsComponentData,

--- a/projects/fsastorefrontlib/src/cms-components/form/personal-details/personal-details.component.ts
+++ b/projects/fsastorefrontlib/src/cms-components/form/personal-details/personal-details.component.ts
@@ -1,5 +1,9 @@
 import { Component } from '@angular/core';
-import { ActiveCartService, AuthService } from '@spartacus/core';
+import {
+  ActiveCartService,
+  AuthService,
+  UserAddressService,
+} from '@spartacus/core';
 import { filter, map, take } from 'rxjs/operators';
 import {
   FormCMSComponent,
@@ -24,9 +28,11 @@ export class PersonalDetailsComponent extends FormCMSComponent {
     protected cartService: ActiveCartService,
     protected formDataService: FormDataService,
     protected formDataStorageService: FormDataStorageService,
-    protected authService: AuthService
+    protected authService: AuthService,
+    protected userAddressService: UserAddressService
   ) {
     super(componentData, formDataService, formDataStorageService);
+    this.userAddressService.loadAddresses();
   }
 
   loadFormDefinition() {

--- a/projects/fsastorefrontlib/src/cms-components/my-account/address-book/address-form/address-form.component.spec.ts
+++ b/projects/fsastorefrontlib/src/cms-components/my-account/address-book/address-form/address-form.component.spec.ts
@@ -1,5 +1,5 @@
 import { ChangeDetectionStrategy } from '@angular/core';
-import { waitForAsync, ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { FormGroup, ReactiveFormsModule } from '@angular/forms';
 import { NgSelectModule } from '@ng-select/ng-select';
 import {
@@ -18,6 +18,7 @@ import {
 import { FormErrorsModule, ModalService } from '@spartacus/storefront';
 import { Observable, of } from 'rxjs';
 import { FSAddressFormComponent } from './address-form.component';
+import { OccValueListService } from '../../../../occ/services/value-list/occ-value-list.service';
 import createSpy = jasmine.createSpy;
 
 class MockUserService {
@@ -55,10 +56,17 @@ const mockAddress: Address = {
   country: { isocode: 'JP' },
   defaultAddress: true,
 };
+const country = { key: 'AU', value: 'Austria' };
+
 class MockModalService {
   open(): any {}
 }
 
+class MockOccValueListService {
+  getValuesFromAPI(): any {
+    return of({ results: [country] });
+  }
+}
 class MockCheckoutDeliveryService {
   clearAddressVerificationResults = createSpy();
   verifyAddress = createSpy();
@@ -100,6 +108,7 @@ describe('FSAddressFormComponent', () => {
             useClass: MockCheckoutDeliveryService,
           },
           { provide: UserService, useClass: MockUserService },
+          { provide: OccValueListService, useClass: MockOccValueListService },
           { provide: UserAddressService, useClass: MockUserAddressService },
           { provide: GlobalMessageService, useValue: mockGlobalMessageService },
           { provide: ModalService, useClass: MockModalService },
@@ -148,6 +157,13 @@ describe('FSAddressFormComponent', () => {
     expect(component.addressForm.get('lastName').value).toEqual(
       mockUser.lastName
     );
+
+    component.countries$
+      .subscribe(countries => {
+        expect(countries.length).toEqual(1);
+        expect(countries[0].isocode).toEqual(country.key);
+      })
+      .unsubscribe();
   });
 
   it('should call ngOnInit without setting initial values for first & last name', () => {

--- a/projects/fsastorefrontlib/src/cms-components/my-account/address-book/address-form/address-form.component.spec.ts
+++ b/projects/fsastorefrontlib/src/cms-components/my-account/address-book/address-form/address-form.component.spec.ts
@@ -56,7 +56,7 @@ const mockAddress: Address = {
   country: { isocode: 'JP' },
   defaultAddress: true,
 };
-const country = { key: 'AU', value: 'Austria' };
+const country = { key: 'AT', value: 'Austria' };
 
 class MockModalService {
   open(): any {}

--- a/projects/fsastorefrontlib/src/cms-components/my-account/address-book/address-form/address-form.component.ts
+++ b/projects/fsastorefrontlib/src/cms-components/my-account/address-book/address-form/address-form.component.ts
@@ -7,12 +7,16 @@ import {
 import { FormBuilder, FormGroup, Validators } from '@angular/forms';
 import {
   CheckoutDeliveryService,
+  Country,
   GlobalMessageService,
   User,
   UserAddressService,
   UserService,
 } from '@spartacus/core';
 import { AddressFormComponent, ModalService } from '@spartacus/storefront';
+import { of } from 'rxjs';
+import { filter, map } from 'rxjs/operators';
+import { OccValueListService } from '../../../../occ/services/value-list/occ-value-list.service';
 
 @Component({
   selector: 'cx-fs-address-form',
@@ -40,13 +44,16 @@ export class FSAddressFormComponent extends AddressFormComponent
     defaultAddress: [true],
   });
 
+  countriesURL = '/catalogs/financialProductCatalog/valueLists/country';
+
   constructor(
     protected fb: FormBuilder,
     protected checkoutDeliveryService: CheckoutDeliveryService,
     protected userService: UserService,
     protected userAddressService: UserAddressService,
     protected globalMessageService: GlobalMessageService,
-    protected modalService: ModalService
+    protected modalService: ModalService,
+    protected occValueListService: OccValueListService
   ) {
     super(
       fb,
@@ -66,6 +73,21 @@ export class FSAddressFormComponent extends AddressFormComponent
     if (this.user?.lastName) {
       this.addressForm.controls.lastName.setValue(this.user.lastName);
     }
+    this.countries$ = this.occValueListService
+      .getValuesFromAPI(this.countriesURL)
+      .pipe(
+        filter(result => result.values),
+        map(result => {
+          const options: Country[] = [];
+          result.values.forEach(item => {
+            options.push({
+              name: item.value,
+              isocode: item.key,
+            });
+          });
+          return options;
+        })
+      );
   }
 
   verifyAddress(): void {

--- a/projects/fsastorefrontlib/src/cms-components/my-account/address-book/address-form/address-form.component.ts
+++ b/projects/fsastorefrontlib/src/cms-components/my-account/address-book/address-form/address-form.component.ts
@@ -14,7 +14,6 @@ import {
   UserService,
 } from '@spartacus/core';
 import { AddressFormComponent, ModalService } from '@spartacus/storefront';
-import { of } from 'rxjs';
 import { filter, map } from 'rxjs/operators';
 import { OccValueListService } from '../../../../occ/services/value-list/occ-value-list.service';
 


### PR DESCRIPTION
New address prefill resolver is introduced to populate address from userAddressService. This is done because user state doesn't have correct address saved.
Address form component is modified to use FSA value list of countries because that list is used on personal details component and they should be the same.