### PR TITLE
FSA-5760: Generates notice messages during assignment/deassignment

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "1.0.0",
   "license": "Apache-2.0",
   "scripts": {
+    "postinstall": "cp -r ./projects/fsastorefrontstyles/fonts ./src/assets",
     "ng": "ng",
     "start": "ng serve",
     "build": "ng build",

--- a/projects/fsastorefrontlib/src/assets/translations/de/b2b.de.ts
+++ b/projects/fsastorefrontlib/src/assets/translations/de/b2b.de.ts
@@ -25,6 +25,7 @@ export const productAssignments = {
     assign: '[DE] Assign',
     remove: '[DE] Remove',
     add: '[DE] Add',
+    deassigned: '[DE] Product {{ item.name }} unassigned successfully',
   },
 };
 
@@ -32,5 +33,6 @@ export const potentialProductAssignments = {
   potentialProductAssignments: {
     title: '[DE] Potential Products',
     subtitle: '[DE] Products which can be assigned to the unit.',
+    assigned: '[DE] Product {{ item.name }} assigned successfully',
   },
 };

--- a/projects/fsastorefrontlib/src/assets/translations/en/b2b.en.ts
+++ b/projects/fsastorefrontlib/src/assets/translations/en/b2b.en.ts
@@ -24,6 +24,7 @@ export const productAssignments = {
     assign: 'Assign',
     remove: 'Remove',
     add: 'Add',
+    deassigned: 'Product {{ item.name }} unassigned successfully',
   },
 };
 
@@ -31,5 +32,6 @@ export const potentialProductAssignments = {
   potentialProductAssignments: {
     title: 'Potential Products',
     subtitle: 'Products which can be assigned to the unit.',
+    assigned: 'Product {{ item.name }} assigned successfully',
   },
 };

--- a/projects/fsastorefrontlib/src/cms-components/b2b/unit/assignments/cells/remove-product-cell/remove-product-cell.component.spec.ts
+++ b/projects/fsastorefrontlib/src/cms-components/b2b/unit/assignments/cells/remove-product-cell/remove-product-cell.component.spec.ts
@@ -1,10 +1,16 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { B2BUnit, I18nTestingModule } from '@spartacus/core';
 import { OutletContextData } from '@spartacus/storefront';
-import { of } from 'rxjs';
-import { CurrentUnitService } from '@spartacus/organization/administration/components';
+import { of, Subject } from 'rxjs';
+import {
+  CurrentUnitService,
+  ItemService,
+  ListService,
+  MessageService,
+} from '@spartacus/organization/administration/components';
 import { ProductAssignmentService } from '../../../../../../core/product-assignment/facade/product-assignment.service';
 import { RemoveProductCellComponent } from './remove-product-cell.component';
+import { FSProductAssignment } from '../../../../../../occ/occ-models/occ.models';
 
 const mockModel = {
   active: false,
@@ -29,11 +35,26 @@ class MockProductAssignmentService {
   }
 }
 
+class MockMessageService {
+  add() {
+    return new Subject();
+  }
+  close() {}
+}
+
+class MockListService {
+  viewType = 'i18nRoot';
+}
+
 describe('RemoveProductCellComponent', () => {
-  let component: RemoveProductCellComponent;
-  let fixture: ComponentFixture<RemoveProductCellComponent>;
+  let component: RemoveProductCellComponent<FSProductAssignment>;
+  let fixture: ComponentFixture<RemoveProductCellComponent<
+    FSProductAssignment
+  >>;
   let productAssignmentService: ProductAssignmentService;
   let currentUnitService: CurrentUnitService;
+  let messageService: MessageService;
+  let organizationListService: ListService<FSProductAssignment>;
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
@@ -54,6 +75,14 @@ describe('RemoveProductCellComponent', () => {
           provide: ProductAssignmentService,
           useClass: MockProductAssignmentService,
         },
+        {
+          provide: MessageService,
+          useClass: MockMessageService,
+        },
+        {
+          provide: ListService,
+          useClass: MockListService,
+        },
       ],
     }).compileComponents();
   });
@@ -64,6 +93,8 @@ describe('RemoveProductCellComponent', () => {
     fixture.detectChanges();
     productAssignmentService = TestBed.inject(ProductAssignmentService);
     currentUnitService = TestBed.inject(CurrentUnitService);
+    organizationListService = TestBed.inject(ListService);
+    messageService = TestBed.inject(MessageService);
     spyOn(
       productAssignmentService,
       'removeProductAssignment'

--- a/projects/fsastorefrontlib/src/cms-components/b2b/unit/assignments/cells/remove-product-cell/remove-product-cell.component.ts
+++ b/projects/fsastorefrontlib/src/cms-components/b2b/unit/assignments/cells/remove-product-cell/remove-product-cell.component.ts
@@ -2,6 +2,8 @@ import { ChangeDetectionStrategy, Component, OnDestroy } from '@angular/core';
 import {
   CellComponent,
   CurrentUnitService,
+  ListService,
+  MessageService,
 } from '@spartacus/organization/administration/components';
 import {
   OutletContextData,
@@ -16,18 +18,21 @@ import { ProductAssignmentService } from '../../../../../../core/product-assignm
   templateUrl: './remove-product-cell.component.html',
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class RemoveProductCellComponent extends CellComponent
+export class RemoveProductCellComponent<FSProductAssignment>
+  extends CellComponent
   implements OnDestroy {
   constructor(
     protected outlet: OutletContextData<TableDataOutletContext>,
     protected productAssignmentService: ProductAssignmentService,
-    protected currentUnitService: CurrentUnitService
+    protected currentUnitService: CurrentUnitService,
+    protected organizationSubListService: ListService<FSProductAssignment>,
+    protected messageService: MessageService
   ) {
     super(outlet);
   }
 
   private subscription = new Subscription();
-
+  protected readonly DEASSIGNED_STATE = 'deassigned';
   currentUnit$ = this.currentUnitService.item$;
 
   removeProduct(unitId, parentUintId) {
@@ -36,6 +41,18 @@ export class RemoveProductCellComponent extends CellComponent
       this.model.assignmentCode,
       parentUintId
     );
+    this.notify(this.model, this.DEASSIGNED_STATE);
+  }
+
+  protected notify(item, state) {
+    this.messageService.add({
+      message: {
+        key: `${this.organizationSubListService.viewType}.${state}`,
+        params: {
+          item,
+        },
+      },
+    });
   }
 
   isUnitDefaultOrganizationOfUser(unitId: string): Observable<boolean> {

--- a/projects/fsastorefrontlib/src/cms-components/b2b/unit/potential-assignments/cells/assign-product-cell/assign-product-cell.component.spec.ts
+++ b/projects/fsastorefrontlib/src/cms-components/b2b/unit/potential-assignments/cells/assign-product-cell/assign-product-cell.component.spec.ts
@@ -1,11 +1,17 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { I18nTestingModule } from '@spartacus/core';
 import { OutletContextData } from '@spartacus/storefront';
-import { of } from 'rxjs';
-import { CurrentUnitService } from '@spartacus/organization/administration/components';
+import { Observable, of, Subject } from 'rxjs';
+import {
+  CurrentUnitService,
+  ItemService,
+  ListService,
+  MessageService,
+} from '@spartacus/organization/administration/components';
 import { ProductAssignmentService } from '../../../../../../core/product-assignment/facade/product-assignment.service';
 
 import { AssignProductCellComponent } from './assign-product-cell.component';
+import { FSProductAssignment } from '../../../../../../occ/occ-models/occ.models';
 
 const mockModel = {
   active: false,
@@ -21,11 +27,28 @@ class MockProductAssignmentService {
   createProductAssignment() {}
 }
 
+class MockMessageService {
+  add() {
+    return new Subject();
+  }
+  close() {}
+}
+
+class MockItemService {}
+
+class MockListService {
+  viewType = 'i18nRoot';
+}
 describe('AssignProductCellComponent', () => {
-  let component: AssignProductCellComponent;
-  let fixture: ComponentFixture<AssignProductCellComponent>;
+  let component: AssignProductCellComponent<FSProductAssignment>;
+  let fixture: ComponentFixture<AssignProductCellComponent<
+    FSProductAssignment
+  >>;
   let productAssignmentService: ProductAssignmentService;
   let currentUnitService: CurrentUnitService;
+  let organizationItemService: ItemService<FSProductAssignment>;
+  let messageService: MessageService;
+  let organizationListService: ListService<FSProductAssignment>;
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
@@ -46,6 +69,18 @@ describe('AssignProductCellComponent', () => {
           provide: ProductAssignmentService,
           useClass: MockProductAssignmentService,
         },
+        {
+          provide: MessageService,
+          useClass: MockMessageService,
+        },
+        {
+          provide: ListService,
+          useClass: MockListService,
+        },
+        {
+          provide: ItemService,
+          useClass: MockItemService,
+        },
       ],
     }).compileComponents();
   });
@@ -56,6 +91,10 @@ describe('AssignProductCellComponent', () => {
     fixture.detectChanges();
     productAssignmentService = TestBed.inject(ProductAssignmentService);
     currentUnitService = TestBed.inject(CurrentUnitService);
+    organizationListService = TestBed.inject(ListService);
+    messageService = TestBed.inject(MessageService);
+    organizationListService = TestBed.inject(ListService);
+    organizationItemService = TestBed.inject(ItemService);
     spyOn(
       productAssignmentService,
       'createProductAssignment'

--- a/projects/fsastorefrontlib/src/cms-components/b2b/unit/potential-assignments/cells/assign-product-cell/assign-product-cell.component.ts
+++ b/projects/fsastorefrontlib/src/cms-components/b2b/unit/potential-assignments/cells/assign-product-cell/assign-product-cell.component.ts
@@ -1,7 +1,10 @@
 import { Component, ChangeDetectionStrategy, OnDestroy } from '@angular/core';
 import {
-  CellComponent,
+  AssignCellComponent,
   CurrentUnitService,
+  ItemService,
+  ListService,
+  MessageService,
 } from '@spartacus/organization/administration/components';
 import {
   OutletContextData,
@@ -15,17 +18,27 @@ import { ProductAssignmentService } from '../../../../../../core/product-assignm
   templateUrl: './assign-product-cell.component.html',
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class AssignProductCellComponent extends CellComponent
+export class AssignProductCellComponent<FSProductAssignment>
+  extends AssignCellComponent<FSProductAssignment>
   implements OnDestroy {
   constructor(
     protected outlet: OutletContextData<TableDataOutletContext>,
     protected productAssignmentService: ProductAssignmentService,
-    protected currentUnitService: CurrentUnitService
+    protected currentUnitService: CurrentUnitService,
+    protected organizationItemService: ItemService<FSProductAssignment>,
+    protected messageService: MessageService,
+    protected organizationSubListService: ListService<FSProductAssignment>
   ) {
-    super(outlet);
+    super(
+      outlet,
+      organizationItemService,
+      messageService,
+      organizationSubListService
+    );
   }
 
   private subscription = new Subscription();
+  protected readonly ASSIGNED_STATE = 'assigned';
   unit$: Observable<string> = this.currentUnitService.b2bUnit$;
 
   addProduct(unit: string) {
@@ -33,6 +46,18 @@ export class AssignProductCellComponent extends CellComponent
       unit,
       this.model.code
     );
+    this.notify(this.model, this.ASSIGNED_STATE);
+  }
+
+  protected notify(item, state) {
+    this.messageService.add({
+      message: {
+        key: `${this.organizationSubListService.viewType}.${state}`,
+        params: {
+          item,
+        },
+      },
+    });
   }
 
   ngOnDestroy(): void {

--- a/projects/fsastorefrontlib/src/occ/occ-models/occ.models.ts
+++ b/projects/fsastorefrontlib/src/occ/occ-models/occ.models.ts
@@ -259,3 +259,10 @@ export interface FSSteps {
   stepParameter: string;
   step: string;
 }
+
+export interface FSProductAssignment {
+  assignmentCode?: string;
+  name?: string;
+  added?: boolean;
+  active?: boolean;
+}

--- a/projects/fsastorefrontstyles/package.json
+++ b/projects/fsastorefrontstyles/package.json
@@ -14,6 +14,9 @@
   "publishConfig": {
     "access": "public"
   },
+  "scripts": {
+    "postinstall": "cp -r ./fonts $INIT_CWD/src/assets"
+  },
   "devDependencies": {
     "sass": "^1.25.0"
   },


### PR DESCRIPTION
Message notice is generated during creation of new product assignment for unit or during removal.
Notice example:
![image](https://user-images.githubusercontent.com/71004931/115391257-91c02600-a1df-11eb-9d6b-8940b4c10837.png)
