### PR TITLE
FSA-5775 [SyncPilot] Speak to Agent

### DIFF
--- a/projects/fsastorefrontlib/src/assets/translations/de/common.de.ts
+++ b/projects/fsastorefrontlib/src/assets/translations/de/common.de.ts
@@ -186,6 +186,10 @@ export const fscommon = {
       existingCouponCodeProvided:
         '[DE] This coupon code is already applied to the current cart.',
     },
+    syncPilot: {
+      speakToAgent: '[DE] Speak to an Agent',
+      needHelp: '[DE] Need Help?',
+    },
     priceCalculationError:
       'Bei der Preisberechnung ist ein Fehler aufgetreten, versuchen Sie es erneut.',
   },

--- a/projects/fsastorefrontlib/src/assets/translations/en/common.en.ts
+++ b/projects/fsastorefrontlib/src/assets/translations/en/common.en.ts
@@ -186,6 +186,10 @@ export const fscommon = {
       existingCouponCodeProvided:
         'This coupon code is already applied to the current cart.',
     },
+    syncPilot: {
+      speakToAgent: 'Speak to an Agent',
+      needHelp: 'Need Help?',
+    },
     attachments: 'Attachments',
     pageNotFoundMessage:
       'Whoops! Sorry, we couldn\'t find that way! Try getting back.', // prettier-ignore

--- a/projects/fsastorefrontlib/src/cms-components/comparison-table/comaprison-table-panel-item/comparison-table-panel-item.component.html
+++ b/projects/fsastorefrontlib/src/cms-components/comparison-table/comaprison-table-panel-item/comparison-table-panel-item.component.html
@@ -1,7 +1,7 @@
 <ng-container *ngIf="product$ | async as product; else loading">
   <ng-container *ngIf="!isLoading; else loading">
     <div class="table-header">
-      <h3 class="table-header-title">{{ product.name }}</h3>
+      <h3 class="table-header-title mb-0">{{ product.name }}</h3>
       <ng-container *ngIf="productPrice; else na">
         <h4 class="table-header-value">{{ productPrice }}</h4>
       </ng-container>

--- a/projects/fsastorefrontlib/src/cms-components/comparison-table/comparison-table-panel/comparison-table-panel.component.html
+++ b/projects/fsastorefrontlib/src/cms-components/comparison-table/comparison-table-panel/comparison-table-panel.component.html
@@ -1,7 +1,9 @@
 <ng-container *ngIf="comparisonPanel$ | async as panel">
   <ng-container *ngIf="billingData$ | async as billingInfo">
     <div class="fixed-column">
-      <div class="table-header"></div>
+      <div class="table-header text-center mb-0">
+        <cx-fs-sync-pilot-connection-component></cx-fs-sync-pilot-connection-component>
+      </div>
       <div class="table-cell-wrapper">
         <div *ngFor="let item of billingInfo.billingTimes" class="table-cell">
           <span class="table-cell-title text-truncate" title="{{ item.name }}">

--- a/projects/fsastorefrontlib/src/cms-components/comparison-table/comparison-table-panel/comparison-table-panel.component.html
+++ b/projects/fsastorefrontlib/src/cms-components/comparison-table/comparison-table-panel/comparison-table-panel.component.html
@@ -2,7 +2,9 @@
   <ng-container *ngIf="billingData$ | async as billingInfo">
     <div class="fixed-column">
       <div class="table-header text-center mb-0">
-        <cx-fs-sync-pilot-connection-component></cx-fs-sync-pilot-connection-component>
+        <ng-container *ngIf="(user$ | async).uid">
+          <cx-fs-sync-pilot-connection-component></cx-fs-sync-pilot-connection-component>
+        </ng-container>
       </div>
       <div class="table-cell-wrapper">
         <div *ngFor="let item of billingInfo.billingTimes" class="table-cell">

--- a/projects/fsastorefrontlib/src/cms-components/comparison-table/comparison-table-panel/comparison-table-panel.component.spec.ts
+++ b/projects/fsastorefrontlib/src/cms-components/comparison-table/comparison-table-panel/comparison-table-panel.component.spec.ts
@@ -8,7 +8,7 @@ import {
   YFormData,
 } from '@spartacus/dynamicforms';
 import { NgbNavModule, NgbTooltipModule } from '@ng-bootstrap/ng-bootstrap';
-import { CmsComponent } from '@spartacus/core';
+import { CmsComponent, UserService } from '@spartacus/core';
 import { CmsComponentData, MediaModule } from '@spartacus/storefront';
 import { of } from 'rxjs';
 import { Observable } from 'rxjs/internal/Observable';
@@ -64,6 +64,11 @@ const formData: YFormData = {
     '{"testContent":{"tripDestination":"Europe","tripStartDate":"2022-02-02"}}',
 };
 
+const mockUser = {
+  uid: 'test@email.com',
+  name: 'testName',
+};
+
 let pricingData: PricingData;
 
 class MockActivatedRoute {
@@ -94,6 +99,13 @@ class MockPricingService {
     return pricingData;
   }
 }
+
+class MockUserService {
+  get() {
+    return of(mockUser);
+  }
+}
+
 describe('ComparisonTablePanelComponent', () => {
   let comparisonTablePanelComponent: ComparisonTablePanelComponent;
   let fixture: ComponentFixture<ComparisonTablePanelComponent>;
@@ -101,6 +113,7 @@ describe('ComparisonTablePanelComponent', () => {
   let mockFormDataService: FormDataService;
   let mockPricingService: PricingService;
   let mockFOrMDataStorageService: FormDataStorageService;
+  let mockUserService: UserService;
   let el: DebugElement;
 
   beforeEach(
@@ -132,6 +145,10 @@ describe('ComparisonTablePanelComponent', () => {
             provide: ActivatedRoute,
             useClass: MockActivatedRoute,
           },
+          {
+            provide: UserService,
+            useClass: MockUserService,
+          },
         ],
         declarations: [
           ComparisonTablePanelComponent,
@@ -142,6 +159,7 @@ describe('ComparisonTablePanelComponent', () => {
       mockFormDataService = TestBed.inject(FormDataService);
       mockPricingService = TestBed.inject(PricingService);
       mockFOrMDataStorageService = TestBed.inject(FormDataStorageService);
+      mockUserService = TestBed.inject(UserService);
     })
   );
 

--- a/projects/fsastorefrontlib/src/cms-components/comparison-table/comparison-table-panel/comparison-table-panel.component.ts
+++ b/projects/fsastorefrontlib/src/cms-components/comparison-table/comparison-table-panel/comparison-table-panel.component.ts
@@ -5,6 +5,7 @@ import {
   OnInit,
 } from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
+import { User, UserService } from '@spartacus/core';
 import {
   FormDataService,
   FormDataStorageService,
@@ -38,8 +39,11 @@ export class ComparisonTablePanelComponent implements OnInit, OnDestroy {
     protected formDataService: FormDataService,
     protected pricingService: PricingService,
     protected formDataStorageService: FormDataStorageService,
+    protected userService: UserService,
     protected activatedRoute: ActivatedRoute
   ) {}
+
+  user$: Observable<User> = this.userService.get();
 
   ngOnInit() {
     this.comparisonPanel$ = this.componentData.data$;

--- a/projects/fsastorefrontlib/src/cms-components/comparison-table/comparison-table.module.ts
+++ b/projects/fsastorefrontlib/src/cms-components/comparison-table/comparison-table.module.ts
@@ -19,6 +19,7 @@ import { PageComponentModule, SpinnerModule } from '@spartacus/storefront';
 import { FSCartService } from '../../core/cart/facade';
 import { PricingService } from '../../core/product-pricing/facade';
 import { FSProductService } from '../../core/product-pricing/facade/product.service';
+import { SyncPilotModule } from '../sync-pilot';
 import { ComparisonTablePanelItemComponent } from './comaprison-table-panel-item/comparison-table-panel-item.component';
 import { ComparisonTableContainerComponent } from './comparison-table-container/comparison-table-container.component';
 import { ComparisonTablePanelComponent } from './comparison-table-panel/comparison-table-panel.component';
@@ -36,6 +37,7 @@ import { ComparisonTableService } from './comparison-table.service';
     NgbNavModule,
     NgbTooltipModule,
     UrlModule,
+    SyncPilotModule,
     ConfigModule.withConfig(<CmsConfig | RoutesConfig | RoutingConfig>{
       cmsComponents: {
         CMSMultiComparisonTabContainer: {

--- a/projects/fsastorefrontlib/src/cms-components/sync-pilot/sync-pilot-connection.component.html
+++ b/projects/fsastorefrontlib/src/cms-components/sync-pilot/sync-pilot-connection.component.html
@@ -1,12 +1,16 @@
 <ng-container *ngIf="component$ | async as component">
-  <div class="row">
-    <button
-      class="primary-button col-12 col-md-3 m-auto btn-block"
-      (click)="
-        establishConnection(component.url, component.channel, component.action)
-      "
-    >
-      {{ component.linkName }}
-    </button>
+  <h3 class="table-header-title mb-0">
+    {{ 'fscommon.syncPilot.needHelp' | cxTranslate }}
+  </h3>
+  <div
+    class="notice link"
+    (click)="
+      establishConnection(component.url, component.channel, component.action)
+    "
+  >
+    <h4 class="fas fa-headset table-header-value notice"></h4>
+    <p class="mb-0 notice link text-truncate">
+      {{ 'fscommon.syncPilot.speakToAgent' | cxTranslate }}
+    </p>
   </div>
 </ng-container>

--- a/projects/fsastorefrontlib/src/cms-components/sync-pilot/sync-pilot-connection.component.spec.ts
+++ b/projects/fsastorefrontlib/src/cms-components/sync-pilot/sync-pilot-connection.component.spec.ts
@@ -1,6 +1,10 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
-import { I18nTestingModule, UserService, WindowRef } from '@spartacus/core';
-import { CmsComponentData } from '@spartacus/storefront';
+import {
+  I18nTestingModule,
+  UserService,
+  WindowRef,
+  CmsService,
+} from '@spartacus/core';
 import { of } from 'rxjs';
 import { SyncPilotConnectionComponent } from './sync-pilot-connection.component';
 
@@ -16,10 +20,11 @@ const mockUser = {
   name: 'testName',
 };
 
-const MockCmsComponentData = {
-  data$: of(componentData),
-  uid: 'test',
-};
+class MockCmsService {
+  getComponentData() {
+    return of(componentData);
+  }
+}
 
 class MockUserService {
   get() {
@@ -30,6 +35,7 @@ class MockUserService {
 describe('SyncPilotConnectionComponent', () => {
   let component: SyncPilotConnectionComponent;
   let fixture: ComponentFixture<SyncPilotConnectionComponent>;
+  let mockCmsService: CmsService;
   let mockUserService: UserService;
   let winRef: WindowRef;
 
@@ -39,8 +45,8 @@ describe('SyncPilotConnectionComponent', () => {
       imports: [I18nTestingModule],
       providers: [
         {
-          provide: CmsComponentData,
-          useValue: MockCmsComponentData,
+          provide: CmsService,
+          useClass: MockCmsService,
         },
         {
           provide: UserService,
@@ -49,6 +55,7 @@ describe('SyncPilotConnectionComponent', () => {
       ],
     }).compileComponents();
     mockUserService = TestBed.inject(UserService);
+    mockCmsService = TestBed.inject(CmsService);
     winRef = TestBed.inject(WindowRef);
   }));
 
@@ -69,9 +76,8 @@ describe('SyncPilotConnectionComponent', () => {
   });
 
   it('should not establish connection with sync pilot', () => {
+    spyOn(mockCmsService, 'getComponentData').and.returnValue(of({}));
     spyOn(winRef.nativeWindow, 'open');
-    spyOn(mockUserService, 'get').and.returnValue(of({}));
-    component.establishConnection('testUrl', 'testChannel', 'join');
     expect(window.open).not.toHaveBeenCalled();
   });
 });

--- a/projects/fsastorefrontlib/src/cms-components/sync-pilot/sync-pilot-connection.component.spec.ts
+++ b/projects/fsastorefrontlib/src/cms-components/sync-pilot/sync-pilot-connection.component.spec.ts
@@ -1,4 +1,4 @@
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
 import {
   I18nTestingModule,
   UserService,
@@ -39,8 +39,8 @@ describe('SyncPilotConnectionComponent', () => {
   let mockUserService: UserService;
   let winRef: WindowRef;
 
-  beforeEach(async(() => {
-    TestBed.configureTestingModule({
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
       declarations: [SyncPilotConnectionComponent],
       imports: [I18nTestingModule],
       providers: [
@@ -57,7 +57,7 @@ describe('SyncPilotConnectionComponent', () => {
     mockUserService = TestBed.inject(UserService);
     mockCmsService = TestBed.inject(CmsService);
     winRef = TestBed.inject(WindowRef);
-  }));
+  });
 
   beforeEach(() => {
     fixture = TestBed.createComponent(SyncPilotConnectionComponent);

--- a/projects/fsastorefrontlib/src/cms-components/sync-pilot/sync-pilot-connection.component.ts
+++ b/projects/fsastorefrontlib/src/cms-components/sync-pilot/sync-pilot-connection.component.ts
@@ -14,7 +14,7 @@ import { map } from 'rxjs/operators';
   templateUrl: './sync-pilot-connection.component.html',
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class SyncPilotConnectionComponent implements OnInit, OnDestroy {
+export class SyncPilotConnectionComponent implements OnDestroy {
   constructor(
     protected cmsService: CmsService,
     protected userService: UserService,
@@ -25,17 +25,12 @@ export class SyncPilotConnectionComponent implements OnInit, OnDestroy {
   protected readonly CHANNEL_PARAM = '?c=';
   protected readonly USER_PARAM = '&nick=';
 
-  component$: Observable<any>;
-  user$: Observable<User>;
+  component$: Observable<any> = this.cmsService.getComponentData(
+    'SyncPilotConnectionComponent'
+  );
+  user$: Observable<User> = this.userService.get();
 
   private subscription = new Subscription();
-
-  ngOnInit() {
-    this.component$ = this.cmsService.getComponentData(
-      'SyncPilotConnectionComponent'
-    );
-    this.user$ = this.userService.get();
-  }
 
   establishConnection(targetUrl: string, channel: string, action: string) {
     this.subscription.add(

--- a/projects/fsastorefrontlib/src/cms-components/sync-pilot/sync-pilot-connection.component.ts
+++ b/projects/fsastorefrontlib/src/cms-components/sync-pilot/sync-pilot-connection.component.ts
@@ -16,9 +16,8 @@ import { map } from 'rxjs/operators';
 })
 export class SyncPilotConnectionComponent implements OnInit, OnDestroy {
   constructor(
-    protected componentData: CmsComponentData<any>,
-    protected userService: UserService,
     protected cmsService: CmsService,
+    protected userService: UserService,
     protected winRef?: WindowRef
   ) {}
 

--- a/projects/fsastorefrontlib/src/cms-components/sync-pilot/sync-pilot-connection.component.ts
+++ b/projects/fsastorefrontlib/src/cms-components/sync-pilot/sync-pilot-connection.component.ts
@@ -1,11 +1,5 @@
-import {
-  ChangeDetectionStrategy,
-  Component,
-  OnDestroy,
-  OnInit,
-} from '@angular/core';
+import { ChangeDetectionStrategy, Component, OnDestroy } from '@angular/core';
 import { UserService, WindowRef, User, CmsService } from '@spartacus/core';
-import { CmsComponentData } from '@spartacus/storefront';
 import { Observable, Subscription } from 'rxjs';
 import { map } from 'rxjs/operators';
 

--- a/projects/fsastorefrontlib/src/cms-components/sync-pilot/sync-pilot-connection.component.ts
+++ b/projects/fsastorefrontlib/src/cms-components/sync-pilot/sync-pilot-connection.component.ts
@@ -4,7 +4,7 @@ import {
   OnDestroy,
   OnInit,
 } from '@angular/core';
-import { UserService, WindowRef } from '@spartacus/core';
+import { UserService, WindowRef, User, CmsService } from '@spartacus/core';
 import { CmsComponentData } from '@spartacus/storefront';
 import { Observable, Subscription } from 'rxjs';
 import { map } from 'rxjs/operators';
@@ -18,6 +18,7 @@ export class SyncPilotConnectionComponent implements OnInit, OnDestroy {
   constructor(
     protected componentData: CmsComponentData<any>,
     protected userService: UserService,
+    protected cmsService: CmsService,
     protected winRef?: WindowRef
   ) {}
 
@@ -26,17 +27,20 @@ export class SyncPilotConnectionComponent implements OnInit, OnDestroy {
   protected readonly USER_PARAM = '&nick=';
 
   component$: Observable<any>;
+  user$: Observable<User>;
 
   private subscription = new Subscription();
 
   ngOnInit() {
-    this.component$ = this.componentData.data$;
+    this.component$ = this.cmsService.getComponentData(
+      'SyncPilotConnectionComponent'
+    );
+    this.user$ = this.userService.get();
   }
 
   establishConnection(targetUrl: string, channel: string, action: string) {
     this.subscription.add(
-      this.userService
-        .get()
+      this.user$
         .pipe(
           map(user => {
             if (user?.uid && user?.name) {

--- a/projects/fsastorefrontstyles/scss/base/comparison-table.scss
+++ b/projects/fsastorefrontstyles/scss/base/comparison-table.scss
@@ -93,6 +93,9 @@ cx-fs-comparison-table-container {
         font-size: var(--cx-h3-font-size);
       }
     }
+    .fas {
+      line-height: $headings-line-height;
+    }
   }
   .table-cell {
     position: relative;


### PR DESCRIPTION
Because of the specific positioning requested for the SyncPilot, placing it in CMS Slots was not an option. Therefore it has been decided to inject it as a regular Angular component. However it still remains a CMS component, since all of its properties were fetched via Spartacus `CmsService`.