### PR TITLE
FSA-5800: Renamed variable masterFormControl to mainFormControl

### DIFF
--- a/projects/dynamicforms/src/core/services/form-dependencies/field-dependency-resolver.service.ts
+++ b/projects/dynamicforms/src/core/services/form-dependencies/field-dependency-resolver.service.ts
@@ -21,11 +21,11 @@ export class FieldDependencyResolverService {
   ) {}
 
   /**
-   * Method used to enable/disable dependent control based on conditions defined at master control
+   * Method used to enable/disable dependent control based on conditions defined at main control
    *
    * @param controlConfig The dependent field config for which dependencies are resolved
    * @param dependentControl The dependent field control for which dependencies are resolved
-   * @param formGroup The form group which tracks value and validity of master form controls
+   * @param formGroup The form group which tracks value and validity of main form controls
    */
   resolveFormControlDependencies(
     controlConfig: any,
@@ -33,18 +33,18 @@ export class FieldDependencyResolverService {
     formGroup: FormGroup
   ) {
     controlConfig.dependsOn.controls.forEach(condition => {
-      const masterFormControl = this.formService.getFormControlForCode(
+      const mainFormControl = this.formService.getFormControlForCode(
         condition.controlName,
         formGroup
       );
-      if (masterFormControl) {
-        if (!masterFormControl.value) {
+      if (mainFormControl) {
+        if (!mainFormControl.value) {
           if (controlConfig.dependsOn.hide === true) {
             controlConfig.hidden = true;
           }
           this.changeControlEnabled(dependentControl, controlConfig, false);
         }
-        masterFormControl.valueChanges.subscribe(fieldValue => {
+        mainFormControl.valueChanges.subscribe(fieldValue => {
           const dependencyValidations = this.geValidationsForCondition(
             condition
           );

--- a/projects/fsastorefrontlib/src/cms-components/dynamic-forms/form-components/dynamic-select/dynamic-select.component.ts
+++ b/projects/fsastorefrontlib/src/cms-components/dynamic-forms/form-components/dynamic-select/dynamic-select.component.ts
@@ -52,14 +52,14 @@ export class DynamicSelectComponent extends AbstractFormComponent
       );
     } else {
       /**
-       * Assign options to dynamic select component which have dependancy on another form control (masterFormControl)
+       * Assign options to dynamic select component which have dependancy on another form control (mainFormControl)
        */
-      const masterFormControl = this.formService.getFormControlForCode(
+      const mainFormControl = this.formService.getFormControlForCode(
         this.config.apiValue.param,
         this.group
       );
       this.subscription.add(
-        masterFormControl.valueChanges
+        mainFormControl.valueChanges
           .pipe(
             switchMap(value => {
               this.isSelectComponentDependant = true;


### PR DESCRIPTION
According to new SAP rules constants renamed. There should be no issue with backward compatibility since all variables used within method scope.