### PR TITLE
Cart-fix: Reverted fields param to FULL

### DIFF
--- a/projects/fsastorefrontlib/src/occ/adapters/cart/default-occ-cart-config.ts
+++ b/projects/fsastorefrontlib/src/occ/adapters/cart/default-occ-cart-config.ts
@@ -6,8 +6,7 @@ export const defaultOccCartConfig: FSOccConfig = {
       endpoints: {
         addToCart: '/users/${userId}/carts/${cartId}/fs-add-to-cart',
         startBundle: '/users/${userId}/carts/${cartId}/fs-start-bundle',
-        cart:
-          '/users/${userId}/carts/${cartId}?fields=DEFAULT,paymentInfo(FULL)',
+        cart: '/users/${userId}/carts/${cartId}?fields=FULL,paymentInfo(FULL)',
       },
     },
   },


### PR DESCRIPTION
Coupon card below mini cart was missing due to DEFAULT object being pulled from BE. Fixed to FULL