### PR TITLE
FSA-5934: Small improvement for back arrow and headline on all pages

### DIFF
--- a/projects/fsastorefrontlib/src/cms-components/change-process/change-process-confirmation/change-process-confirmation.component.html
+++ b/projects/fsastorefrontlib/src/cms-components/change-process/change-process-confirmation/change-process-confirmation.component.html
@@ -13,7 +13,7 @@
       <p class="text-center">
         {{ 'changeRequest.confirmation.message' | cxTranslate }}
 
-        <a class="overview-section-link" routerLink="/my-account/inbox/">{{
+        <a routerLink="/my-account/inbox/">{{
           'changeRequest.confirmation.inbox' | cxTranslate
         }}</a>
       </p>

--- a/projects/fsastorefrontlib/src/cms-components/my-account/claim/claim-details/claim-details.component.html
+++ b/projects/fsastorefrontlib/src/cms-components/my-account/claim/claim-details/claim-details.component.html
@@ -1,7 +1,7 @@
 <ng-container *ngIf="claim$ | async as claim">
-  <div class="overview-section mb-5">
+  <div class="position-relative text-center">
     <a
-      class="h4 overview-section-link"
+      class="h4 vertical-center-left"
       routerLink="/my-account/my-insurance-claims/"
     >
       <span class="fas fa-arrow-left"></span

--- a/projects/fsastorefrontlib/src/cms-components/my-account/policy/policy-details/policy-details.component.html
+++ b/projects/fsastorefrontlib/src/cms-components/my-account/policy/policy-details/policy-details.component.html
@@ -1,7 +1,7 @@
 <ng-container *ngIf="policy$ | async as policy">
-  <div class="overview-section mb-5">
+  <div class="position-relative text-center">
     <a
-      class="h4 overview-section-link"
+      class="h4 vertical-center-left"
       routerLink="/my-account/my-policies/"
       routerLinkActive="active"
     >

--- a/projects/fsastorefrontlib/src/cms-components/my-account/quote/quote-details/quote-details.component.html
+++ b/projects/fsastorefrontlib/src/cms-components/my-account/quote/quote-details/quote-details.component.html
@@ -1,7 +1,7 @@
 <ng-container *ngIf="quote$ | async as quote">
-  <div class="overview-section mb-5">
+  <div class="position-relative text-center">
     <a
-      class="h4 overview-section-link"
+      class="h4 vertical-center-left"
       routerLink="/my-account/my-financial-applications/"
       routerLinkActive="active"
     >

--- a/projects/fsastorefrontstyles/scss/components/account/_account-details.scss
+++ b/projects/fsastorefrontstyles/scss/components/account/_account-details.scss
@@ -1,25 +1,6 @@
 %cx-fs-policy-details,
 %cx-fs-claim-details {
   width: 100%;
-  .overview-section {
-    color: var(--cx-color-secondary);
-    position: relative;
-    &-value {
-      display: block;
-      color: var(--cx-color-text);
-      padding-bottom: 10px;
-      font-weight: var(--cx-font-weight-semi);
-      @include media-breakpoint-down(md) {
-        font-size: $h5-font-size;
-      }
-    }
-    &-link {
-      @include vertical-center;
-      left: 0;
-      background: transparent;
-      z-index: 1;
-    }
-  }
   .content-box {
     text-align: center;
     background-color: var(--cx-color-1);


### PR DESCRIPTION
Based on @SofijaTrajkovic suggestion, unified headline and back arrow HTML structure, removed unnecessary code.