### PR TITLE
FSA-6039: Tooltip texts updated to include organization and member instead of unit and user

### DIFF
--- a/projects/fsastorefrontlib/src/assets/translations/de/b2b.de.ts
+++ b/projects/fsastorefrontlib/src/assets/translations/de/b2b.de.ts
@@ -21,7 +21,7 @@ export const organization = {
       title: '[DE] Organization Details',
       subtitle: '[DE] Organization: {{ item.name }}',
       hint:
-        '[DE] Organizations represent departments, stores, regions, or any other logical grouping that makes sense to you. Disabling a organization disables all children of the organization, including child organizations and members. Disabled organizations cannot be edited.',
+        '[DE] Organizations represent departments, stores, regions, or any other logical grouping that makes sense to you. Disabling an organization disables all children of the organization, including child organizations and members. Disabled organizations cannot be edited.',
     },
     edit: {
       title: '[DE] Edit Organization',
@@ -91,7 +91,7 @@ export const organization = {
     orgUnit: '[DE] Organization',
     assignApprover: '[DE] Add the user to approvers for the organization',
     hint:
-      '[DE] Members are the buyers and administrators of your organization. Each member is assigned a role for making purchases or administrating organization. Each member belongs to a organization, and they have access to all child organizations of their primary organization.',
+      '[DE] Members are the buyers and administrators of your organization. Each member is assigned a role for making purchases or administrating organization. Each member belongs to an organization, and they have access to all child organizations of their primary organization.',
   },
 };
 

--- a/projects/fsastorefrontlib/src/assets/translations/de/b2b.de.ts
+++ b/projects/fsastorefrontlib/src/assets/translations/de/b2b.de.ts
@@ -15,9 +15,13 @@ export const organization = {
     header: '[DE] All organizations ({{count}})',
     unit: '[DE] Organization',
     parentUnit: '[DE] Parent Organization',
+    hint:  '[DE] Organizations represent departments, stores, regions, or any other logical grouping that makes sense to you. Members have access to all child organizations of their primary organization.',
     details: {
       title: '[DE] Organization Details',
       subtitle: '[DE] Organization: {{ item.name }}',
+      hint:
+        '[DE] Organizations represent departments, stores, regions, or any other logical grouping that makes sense to you. Disabling a organization disables all children of the organization, including child organizations and members. Disabled organizations cannot be edited.'
+
     },
     edit: {
       title: '[DE] Edit Organization',
@@ -64,6 +68,9 @@ export const organization = {
   orgUnitChildren: {
     title: '[DE] Child organization',
     subtitle: '[DE] Organization: {{item.name}}',
+    hint:
+      '[DE] Organizations represent departments, stores, regions, or any other logical grouping that makes sense to you. Members "inherit" child organizations.',
+
   },
   orgUnitApprovers: {
     subtitle: '[DE] Organization: {{item.name}}',
@@ -77,11 +84,17 @@ export const organization = {
   orgUnitUsers: {
     title: '[DE] Organization: {{item.name}}',
     subtitle: '[DE] Organization: {{item.name}}',
+    hint:
+      '[DE] Members are the buyers and administrators of your organization. Each member is assigned a role for making purchases or administrating organization. Members "inherit" child organizations.',
+
   },
   orgUser: {
     unit: '[DE] Organization',
     orgUnit: '[DE] Organization',
     assignApprover: '[DE] Add the user to approvers for the organization',
+    hint:
+      '[DE] Members are the buyers and administrators of your organization. Each member is assigned a role for making purchases or administrating organization. Each member belongs to a organization, and they have access to all child organizations of their primary organization.',
+
   },
 };
 

--- a/projects/fsastorefrontlib/src/assets/translations/de/b2b.de.ts
+++ b/projects/fsastorefrontlib/src/assets/translations/de/b2b.de.ts
@@ -15,13 +15,13 @@ export const organization = {
     header: '[DE] All organizations ({{count}})',
     unit: '[DE] Organization',
     parentUnit: '[DE] Parent Organization',
-    hint:  '[DE] Organizations represent departments, stores, regions, or any other logical grouping that makes sense to you. Members have access to all child organizations of their primary organization.',
+    hint:
+      '[DE] Organizations represent departments, stores, regions, or any other logical grouping that makes sense to you. Members have access to all child organizations of their primary organization.',
     details: {
       title: '[DE] Organization Details',
       subtitle: '[DE] Organization: {{ item.name }}',
       hint:
-        '[DE] Organizations represent departments, stores, regions, or any other logical grouping that makes sense to you. Disabling a organization disables all children of the organization, including child organizations and members. Disabled organizations cannot be edited.'
-
+        '[DE] Organizations represent departments, stores, regions, or any other logical grouping that makes sense to you. Disabling a organization disables all children of the organization, including child organizations and members. Disabled organizations cannot be edited.',
     },
     edit: {
       title: '[DE] Edit Organization',
@@ -70,7 +70,6 @@ export const organization = {
     subtitle: '[DE] Organization: {{item.name}}',
     hint:
       '[DE] Organizations represent departments, stores, regions, or any other logical grouping that makes sense to you. Members "inherit" child organizations.',
-
   },
   orgUnitApprovers: {
     subtitle: '[DE] Organization: {{item.name}}',
@@ -86,7 +85,6 @@ export const organization = {
     subtitle: '[DE] Organization: {{item.name}}',
     hint:
       '[DE] Members are the buyers and administrators of your organization. Each member is assigned a role for making purchases or administrating organization. Members "inherit" child organizations.',
-
   },
   orgUser: {
     unit: '[DE] Organization',
@@ -94,7 +92,6 @@ export const organization = {
     assignApprover: '[DE] Add the user to approvers for the organization',
     hint:
       '[DE] Members are the buyers and administrators of your organization. Each member is assigned a role for making purchases or administrating organization. Each member belongs to a organization, and they have access to all child organizations of their primary organization.',
-
   },
 };
 

--- a/projects/fsastorefrontlib/src/assets/translations/en/b2b.en.ts
+++ b/projects/fsastorefrontlib/src/assets/translations/en/b2b.en.ts
@@ -15,12 +15,13 @@ export const organization = {
     header: 'All organizations ({{count}})',
     unit: 'Organization',
     parentUnit: 'Parent Organization',
-    hint:  'Organizations represent departments, stores, regions, or any other logical grouping that makes sense to you. Members have access to all child organizations of their primary organization.',
+    hint:
+      'Organizations represent departments, stores, regions, or any other logical grouping that makes sense to you. Members have access to all child organizations of their primary organization.',
     details: {
       title: 'Organization Details',
       subtitle: 'Organization: {{ item.name }}',
       hint:
-        'Organizations represent departments, stores, regions, or any other logical grouping that makes sense to you. Disabling a organization disables all children of the organization, including child organizations and members. Disabled organizations cannot be edited.'
+        'Organizations represent departments, stores, regions, or any other logical grouping that makes sense to you. Disabling a organization disables all children of the organization, including child organizations and members. Disabled organizations cannot be edited.',
     },
     edit: {
       title: 'Edit Organization',

--- a/projects/fsastorefrontlib/src/assets/translations/en/b2b.en.ts
+++ b/projects/fsastorefrontlib/src/assets/translations/en/b2b.en.ts
@@ -15,9 +15,12 @@ export const organization = {
     header: 'All organizations ({{count}})',
     unit: 'Organization',
     parentUnit: 'Parent Organization',
+    hint:  'Organizations represent departments, stores, regions, or any other logical grouping that makes sense to you. Members have access to all child organizations of their primary organization.',
     details: {
       title: 'Organization Details',
       subtitle: 'Organization: {{ item.name }}',
+      hint:
+        'Organizations represent departments, stores, regions, or any other logical grouping that makes sense to you. Disabling a organization disables all children of the organization, including child organizations and members. Disabled organizations cannot be edited.'
     },
     edit: {
       title: 'Edit Organization',
@@ -64,6 +67,8 @@ export const organization = {
   orgUnitChildren: {
     title: 'Child organization',
     subtitle: 'Organization: {{item.name}}',
+    hint:
+      'Organizations represent departments, stores, regions, or any other logical grouping that makes sense to you. Members "inherit" child organizations.',
   },
   orgUnitApprovers: {
     subtitle: 'Organization: {{item.name}}',
@@ -76,11 +81,15 @@ export const organization = {
   },
   orgUnitUsers: {
     subtitle: 'Organization: {{item.name}}',
+    hint:
+      'Members are the buyers and administrators of your organization. Each member is assigned a role for making purchases or administrating organization. Members "inherit" child organizations.',
   },
   orgUser: {
     unit: 'Organization',
     orgUnit: 'Organization',
     assignApprover: 'Add the user to approvers for the organization',
+    hint:
+      'Members are the buyers and administrators of your organization. Each member is assigned a role for making purchases or administrating organization. Each member belongs to a organization, and they have access to all child organizations of their primary organization.',
   },
 };
 export const productAssignments = {

--- a/projects/fsastorefrontlib/src/assets/translations/en/b2b.en.ts
+++ b/projects/fsastorefrontlib/src/assets/translations/en/b2b.en.ts
@@ -21,7 +21,7 @@ export const organization = {
       title: 'Organization Details',
       subtitle: 'Organization: {{ item.name }}',
       hint:
-        'Organizations represent departments, stores, regions, or any other logical grouping that makes sense to you. Disabling a organization disables all children of the organization, including child organizations and members. Disabled organizations cannot be edited.',
+        'Organizations represent departments, stores, regions, or any other logical grouping that makes sense to you. Disabling an organization disables all children of the organization, including child organizations and members. Disabled organizations cannot be edited.',
     },
     edit: {
       title: 'Edit Organization',
@@ -90,7 +90,7 @@ export const organization = {
     orgUnit: 'Organization',
     assignApprover: 'Add the user to approvers for the organization',
     hint:
-      'Members are the buyers and administrators of your organization. Each member is assigned a role for making purchases or administrating organization. Each member belongs to a organization, and they have access to all child organizations of their primary organization.',
+      'Members are the buyers and administrators of your organization. Each member is assigned a role for making purchases or administrating organization. Each member belongs to an organization, and they have access to all child organizations of their primary organization.',
   },
 };
 export const productAssignments = {

--- a/projects/fsastorefrontlib/src/cms-components/form/general-information/general-information.component.spec.ts
+++ b/projects/fsastorefrontlib/src/cms-components/form/general-information/general-information.component.spec.ts
@@ -142,6 +142,11 @@ describe('GeneralInformationComponent', () => {
     expect(component).toBeTruthy();
   });
 
+  it('should load form data', () => {
+    component.ngOnInit();
+    expect(mockFormDataService.loadFormData).toHaveBeenCalled();
+  });
+
   it('should load form definition data', () => {
     spyOn(mockFormDataService, 'loadFormDefinitions').and.callThrough();
     spyOn(mockFormDataService, 'getFormDefinition').and.callThrough();

--- a/projects/fsastorefrontlib/src/cms-components/form/general-information/general-information.component.ts
+++ b/projects/fsastorefrontlib/src/cms-components/form/general-information/general-information.component.ts
@@ -63,7 +63,7 @@ export class GeneralInformationComponent extends FormCMSComponent
         .pipe(
           map(cart => {
             if (cart.code) {
-              const bindingState = (<FSCart>cart).insuranceQuote.state.code;
+              const bindingState = (<FSCart>cart).insuranceQuote?.state?.code;
               const chooseCoverFormId = (<FSCart>cart).insuranceQuote
                 ?.quoteDetails?.formId;
               if (bindingState !== BindingStateType.BIND && chooseCoverFormId) {


### PR DESCRIPTION

+ fix for null pointer on general information component


![Screenshot 2021-08-06 at 16 51 43](https://user-images.githubusercontent.com/69310701/128529419-888a00e6-3666-4fff-8365-7336480371fd.png)
