### PR TITLE
NO-TASK: Setting AOT compiling to false for development

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -54,6 +54,7 @@
               ]
             },
             "development": {
+              "aot": false,
               "buildOptimizer": false,
               "optimization": false,
               "vendorChunk": true,


### PR DESCRIPTION
This setting allows us to cut compile time during development to 1.5s. This setting was default before Angular 11.
This means that errors coming from templates, or unknown component properties will again show ONLY in browser console, not in the Angular console.