### PR TITLE
CXFSA-557: Added validators

### DIFF
--- a/projects/dynamicforms/src/util/validators/default-form-validators.spec.ts
+++ b/projects/dynamicforms/src/util/validators/default-form-validators.spec.ts
@@ -39,7 +39,7 @@ describe('FormValidationService', () => {
     form.get(field1).setValue('fieldValue');
     form.get(field2).setValue('otherValue');
     expect(DefaultFormValidators.matchFields(field1, field2)(form)).toEqual({
-      NotEqual: true,
+      notEqual: true,
     });
   });
 
@@ -47,7 +47,7 @@ describe('FormValidationService', () => {
     form.get(dateOfBirth).setValue('10-10-2015');
     expect(
       DefaultFormValidators.dateOfBirthValidator(18)(form.get(dateOfBirth))
-    ).toEqual({ InvalidDate: true });
+    ).toEqual({ invalidAge: true });
   });
 
   it('should not return error, when person is older then minimun age', () => {
@@ -61,7 +61,7 @@ describe('FormValidationService', () => {
     form.get(field1).setValue('testValue');
     expect(
       DefaultFormValidators.shouldContainValue('notExist')(form.get(field1))
-    ).toEqual({ valueConflict: true });
+    ).toEqual({ noValue: true });
   });
 
   it('should not return error, when field contains given value', () => {
@@ -113,7 +113,7 @@ describe('FormValidationService', () => {
     form.get(field1).setValue('testValue');
     expect(
       DefaultFormValidators.regexValidator(numberLetterRegex)(form.get(field1))
-    ).toEqual({ InvalidFormat: true });
+    ).toEqual({ invalidFormat: true });
   });
 
   it('should not return error, when field contains numbers only', () => {
@@ -150,7 +150,7 @@ describe('FormValidationService', () => {
         dateToCompare,
         'shouldBeGreater'
       )
-    ).toEqual({ valueConflict: true });
+    ).toEqual({ valueShouldBeGreater: true });
 
     expect(
       DefaultFormValidators.valueComparison(
@@ -158,7 +158,7 @@ describe('FormValidationService', () => {
         dateToCompare2,
         'shouldBeLess'
       )
-    ).toEqual({ valueConflict: true });
+    ).toEqual({ valueShouldBeLess: true });
 
     expect(
       DefaultFormValidators.valueComparison(
@@ -189,19 +189,19 @@ describe('FormValidationService', () => {
       DefaultFormValidators.compareToCurrentDate('shouldBeEqual')(
         form.get(date1)
       )
-    ).toEqual({ InvalidDate: true });
+    ).toEqual({ dateShouldBeEqual: true });
 
     expect(
       DefaultFormValidators.compareToCurrentDate('shouldBeGreater')(
         form.get(date1)
       )
-    ).toEqual({ InvalidDate: true });
+    ).toEqual({ dateShouldBeGreater: true });
 
     expect(
       DefaultFormValidators.compareToCurrentDate('shouldBeGreaterOrEqual')(
         form.get(date1)
       )
-    ).toEqual({ InvalidDate: true });
+    ).toEqual({ dateShouldBeGreaterOrEqual: true });
   });
 
   it('should compare date in future with current date', () => {
@@ -212,19 +212,19 @@ describe('FormValidationService', () => {
       DefaultFormValidators.compareToCurrentDate('shouldBeLess')(
         form.get(date1)
       )
-    ).toEqual({ InvalidDate: true });
+    ).toEqual({ dateShouldBeLess: true });
 
     expect(
       DefaultFormValidators.compareToCurrentDate('shouldBeLessOrEqual')(
         form.get(date1)
       )
-    ).toEqual({ InvalidDate: true });
+    ).toEqual({ dateShouldBeLessOrEqual: true });
 
     expect(
       DefaultFormValidators.compareToCurrentDate('shouldBeEqual')(
         form.get(date1)
       )
-    ).toEqual({ InvalidDate: true });
+    ).toEqual({ dateShouldBeEqual: true });
 
     expect(
       DefaultFormValidators.compareToCurrentDate('shouldBeGreater')(
@@ -245,7 +245,7 @@ describe('FormValidationService', () => {
 
     expect(
       DefaultFormValidators.compareDates(date2, 'shouldBeLess')(form.get(date1))
-    ).toEqual({ valueConflict: true });
+    ).toEqual({ valueShouldBeLess: true });
 
     expect(
       DefaultFormValidators.compareDates(
@@ -271,7 +271,7 @@ describe('FormValidationService', () => {
         field2,
         'shouldBeGreater'
       )(form.get(field1))
-    ).toEqual({ valueConflict: true });
+    ).toEqual({ valueShouldBeGreater: true });
   });
 
   it('should age and date of birth fields', () => {
@@ -290,14 +290,14 @@ describe('FormValidationService', () => {
         dateOfBirth,
         'shouldBeGreater'
       )(form.get(field1))
-    ).toEqual({ valueConflict: true });
+    ).toEqual({ valueShouldBeGreater: true });
 
     expect(
       DefaultFormValidators.compareDOBtoAge(
         field1,
         'shouldBeLess'
       )(form.get(dateOfBirth))
-    ).toEqual({ valueConflict: true });
+    ).toEqual({ valueShouldBeLess: true });
 
     expect(
       DefaultFormValidators.compareDOBtoAge(

--- a/projects/dynamicforms/src/util/validators/default-form-validators.ts
+++ b/projects/dynamicforms/src/util/validators/default-form-validators.ts
@@ -23,9 +23,13 @@ export class DefaultFormValidators extends Validators {
     if (baseValue && comparisonValue) {
       switch (operator) {
         case 'shouldBeGreater':
-          return baseValue > comparisonValue ? null : { valueShouldBeGreater: true };
+          return baseValue > comparisonValue
+            ? null
+            : { valueShouldBeGreater: true };
         case 'shouldBeLess':
-          return baseValue < comparisonValue ? null : { valueShouldBeLess: true };
+          return baseValue < comparisonValue
+            ? null
+            : { valueShouldBeLess: true };
       }
     }
   }

--- a/projects/dynamicforms/src/util/validators/default-form-validators.ts
+++ b/projects/dynamicforms/src/util/validators/default-form-validators.ts
@@ -23,9 +23,9 @@ export class DefaultFormValidators extends Validators {
     if (baseValue && comparisonValue) {
       switch (operator) {
         case 'shouldBeGreater':
-          return baseValue > comparisonValue ? null : { valueConflict: true };
+          return baseValue > comparisonValue ? null : { valueShouldBeGreater: true };
         case 'shouldBeLess':
-          return baseValue < comparisonValue ? null : { valueConflict: true };
+          return baseValue < comparisonValue ? null : { valueShouldBeLess: true };
       }
     }
   }
@@ -60,16 +60,16 @@ export class DefaultFormValidators extends Validators {
         if (regex === this.phoneNumberRegex) {
           return field.match(regex) ? null : { cxInvalidPhoneRegex: true };
         }
-        return field.match(regex) ? null : { InvalidFormat: true };
+        return field.match(regex) ? null : { invalidFormat: true };
       }
       return null;
     };
   }
 
   static matchFields(controlName: string, controlName2: string) {
-    return (control: AbstractControl): { NotEqual: boolean } => {
+    return (control: AbstractControl): { notEqual: boolean } => {
       if (control.get(controlName).value !== control.get(controlName2).value) {
-        return { NotEqual: true };
+        return { notEqual: true };
       }
     };
   }
@@ -83,7 +83,7 @@ export class DefaultFormValidators extends Validators {
         today.getMonth(),
         today.getDate()
       );
-      return userAge < age ? null : { InvalidDate: true };
+      return userAge < age ? null : { invalidAge: true };
     };
   }
 
@@ -176,23 +176,23 @@ export class DefaultFormValidators extends Validators {
         case 'shouldBeEqual':
           return inputVal.getTime() === today.getTime()
             ? null
-            : { InvalidDate: true };
+            : { dateShouldBeEqual: true };
         case 'shouldBeGreater':
           return inputVal.getTime() > today.getTime()
             ? null
-            : { InvalidDate: true };
+            : { dateShouldBeGreater: true };
         case 'shouldBeLess':
           return inputVal.getTime() < today.getTime()
             ? null
-            : { InvalidDate: true };
+            : { dateShouldBeLess: true };
         case 'shouldBeGreaterOrEqual':
           return inputVal.getTime() >= today.getTime()
             ? null
-            : { InvalidDate: true };
+            : { dateShouldBeGreaterOrEqual: true };
         case 'shouldBeLessOrEqual':
           return inputVal.getTime() <= today.getTime()
             ? null
-            : { InvalidDate: true };
+            : { dateShouldBeLessOrEqual: true };
       }
     };
   }
@@ -241,7 +241,7 @@ export class DefaultFormValidators extends Validators {
   static shouldContainValue(value) {
     return (control: AbstractControl): ValidationErrors | null => {
       const valid = control.value.indexOf(value) !== -1;
-      return valid ? null : { valueConflict: true };
+      return valid ? null : { noValue: true };
     };
   }
 }

--- a/projects/fsastorefrontlib/src/assets/translations/overrides/de/common.ts
+++ b/projects/fsastorefrontlib/src/assets/translations/overrides/de/common.ts
@@ -83,7 +83,9 @@ export const common = {
     pattern: '[DE] Should contain at least one number, no special characters',
     maxlength: '[DE] Maximum {{ maxLength }} characters',
     min: '[DE] Minimum value is {{ minValue }} {{ measure }}',
-    InvalidDate: '[DE] Must be over 18 years old',
+    invalidAge: '[DE] Must be over 18 years old',
+    dateShouldBeGreaterOrEqual: '[DE] Date cannot be in the past',
+    dateShouldBeGreater: '[DE] Date must be in the future',
     cxInvalidPassword:
       '[DE] Password must be six characters minimum, with one uppercase letter, one number, one symbol',
     cxInvalidPhoneRegex:

--- a/projects/fsastorefrontlib/src/assets/translations/overrides/en/common.ts
+++ b/projects/fsastorefrontlib/src/assets/translations/overrides/en/common.ts
@@ -58,7 +58,9 @@ export const common = {
     pattern: 'Should contain at least one number, no special characters',
     maxlength: 'Maximum {{ maxLength }} characters',
     min: 'Minimum value is {{ minValue }} {{ measure }}',
-    InvalidDate: 'Must be over 18 years old',
+    invalidAge: 'Must be over 18 years old',
+    dateShouldBeGreaterOrEqual: 'Date cannot be in the past',
+    dateShouldBeGreater: 'Date must be in the future',
     cxInvalidPassword:
       'Password must be six characters minimum, with one uppercase letter, one number, one symbol',
     cxInvalidPhoneRegex:

--- a/projects/fsastorefrontlib/src/cms-components/agent/appointment-scheduling/appointment-scheduling-form.component.html
+++ b/projects/fsastorefrontlib/src/cms-components/agent/appointment-scheduling/appointment-scheduling-form.component.html
@@ -8,6 +8,7 @@
       class="form-control"
       type="text"
       formControlName="subject"
+      [maxLength]="subjectMaxLength"
       placeholder="{{
         'appointmentScheduling.placeholder.subject' | cxTranslate
       }}"
@@ -23,7 +24,7 @@
       class="form-control"
       type="date"
       formControlName="appointmentDate"
-      min="{{ date | date: 'yyyy-MM-dd' }}"
+      [min]="tomorrow | date: 'yyyy-MM-dd'"
     />
     <cx-form-errors [control]="form.get('appointmentDate')"></cx-form-errors>
   </div>
@@ -51,7 +52,8 @@
     >
     <textarea
       id="description"
-      rows="10"
+      [maxLength]="descriptionMaxLength"
+      rows="5"
       class="form-control"
       type="text"
       formControlName="description"

--- a/projects/fsastorefrontlib/src/cms-components/agent/appointment-scheduling/appointment-scheduling-form.component.spec.ts
+++ b/projects/fsastorefrontlib/src/cms-components/agent/appointment-scheduling/appointment-scheduling-form.component.spec.ts
@@ -86,15 +86,33 @@ describe('AppointmentSchedulingFormComponent', () => {
     );
 
     component.form.setValue({
-      subject: 'test',
-      appointmentDate: 'test',
-      appointmentTime: 'test',
-      description: 'test',
+      subject: 'Test subject',
+      appointmentDate: new Date('2030-02-11T13:02:58+0000'),
+      appointmentTime: '10:00 (1h)',
+      description: 'Test description',
       consentGiven: true,
     });
 
     component.submit();
     expect(component.submit).toHaveBeenCalled();
     expect(component.form.valid).toBeTrue();
+  });
+
+  it('should NOT call submit with INVALID appointment date', () => {
+    spyOn(component, 'submit').and.callThrough();
+    appointmentSchedulingServiceSpy.createAppointment.and.returnValue(
+      of('Test')
+    );
+
+    component.form.setValue({
+      subject: 'Test subject',
+      appointmentDate: new Date('2010-02-11T13:02:58+0000'),
+      appointmentTime: '10:00 (1h)',
+      description: 'Test description',
+      consentGiven: true,
+    });
+
+    component.submit();
+    expect(component.form.valid).toBeFalse();
   });
 });


### PR DESCRIPTION
Changed error properties in `default-form-validators` in `dynamicForms`. This is because majority of date errors were tied to `invalidDate` property which we've mapped in our translations like 'You must be over 18 years old', which is not applicable in this case (or any other case other than checking age).